### PR TITLE
Fixed issue in which the objects of the remember environments would not appear

### DIFF
--- a/mikasa_robo_suite/memory_envs/remember_color.py
+++ b/mikasa_robo_suite/memory_envs/remember_color.py
@@ -194,9 +194,9 @@ class RememberColorBaseEnv(BaseEnv):
             else:
                 raise NotImplementedError(self.robot_uids)
 
-    def evaluate(self):
         self.original_poses = {key: self.cubes[key].pose.raw_pose.clone() for key in self.cubes.keys()}
-        
+
+    def evaluate(self):
         hidden_shapes_poses = {}
         for key, shape in self.color_dict.items():
             hidden_shapes_poses[key] = self.cubes[key].pose.raw_pose.clone()

--- a/mikasa_robo_suite/memory_envs/remember_shape.py
+++ b/mikasa_robo_suite/memory_envs/remember_shape.py
@@ -287,9 +287,9 @@ class RememberShapeBaseEnv(BaseEnv):
             else:
                 raise NotImplementedError(self.robot_uids)
 
-    def evaluate(self):
         self.original_poses = {key: self.shapes[key].pose.raw_pose.clone() for key in self.shapes.keys()}
 
+    def evaluate(self):
         hidden_shapes_poses = {}
         for key, shape in self.shape_dict.items():
             hidden_shapes_poses[key] = self.shapes[key].pose.raw_pose.clone()

--- a/mikasa_robo_suite/memory_envs/remember_shape_and_color.py
+++ b/mikasa_robo_suite/memory_envs/remember_shape_and_color.py
@@ -280,9 +280,9 @@ class RememberShapeAndColorBaseEnv(BaseEnv):
             else:
                 raise NotImplementedError(self.robot_uids)
 
-    def evaluate(self):
         self.original_poses = {key: self.shapes[key].pose.raw_pose.clone() for key in self.shapes.keys()}
 
+    def evaluate(self):
         hidden_shapes_poses = {}
         for key, shape in self.shape_color_dict.items():
             hidden_shapes_poses[key] = self.shapes[key].pose.raw_pose.clone()


### PR DESCRIPTION
In all Remember* environments, `self.original_poses` is set at the beginning of `evaluate()` instead of at the end of `_initialize_episode`, where it should be. This results in the objects never appearing in the field of view. This PR fixes that.